### PR TITLE
Add requirements file for Binder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+wheel
+https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.0-cp35-cp35m-linux_x86_64.whl
+numpy
+matplotlib


### PR DESCRIPTION
This allows mybinder.org to build a working environment (and also serves as documentation for those wanting to deploy it locally). Probably can be used in the README.md too!

Example: https://mybinder.org/v2/gh/luizirber/neural-net-study-group/binder?filepath=notebooks%2Flinear_regression.ipynb